### PR TITLE
implement suggested improvements

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ const Autobase = require('autobase')
 const Base = require('bfx-facs-base')
 const Corestore = require('corestore')
 const Hyperbee = require('hyperbee')
-const Hyperswarm = require('hyperswarm')
 
 class StoreFacility extends Base {
   constructor (caller, opts, ctx) {
@@ -16,17 +15,17 @@ class StoreFacility extends Base {
     this.init()
   }
 
-  async getCore (opts = {}) {
+  getCore (opts = {}) {
     return this.store.get(opts)
   }
 
-  async getBee (opts = {}, beeOpts = {}) {
+  getBee (opts = {}, beeOpts = {}) {
     const hc = this.store.get(opts)
 
     return new Hyperbee(hc, beeOpts)
   }
 
-  async getBase (baseOpts, boostrapKey = null) {
+  getBase (baseOpts, boostrapKey = null) {
     return new Autobase(this.store.session(), boostrapKey, baseOpts)
   }
 
@@ -54,22 +53,6 @@ class StoreFacility extends Base {
     await bee.core.setUserData(`${prefix}-checkout`, '' + bee.core.length)
 
     await co.close()
-  }
-
-  async swarmBase (base) {
-    if (!this.swarm) {
-      this.swarm = new Hyperswarm({ keypair: base.local.keyPair })
-      this.swarm.on('connection', (connection) => base.replicate(connection))
-      this.swarm.join(base.discoveryKey)
-      return this.swarm
-    } else {
-      throw new Error('ERR_FACS_STORE_CANNOT_CREATE_MULTIPLE_SWARM_BASE')
-    }
-  }
-
-  // TODO: Should we remove this function?
-  async exists (_key) {
-    return true
   }
 
   async unlink (_key) {

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
     "bfx-facs-base": "git+https://github.com/bitfinexcom/bfx-facs-base.git",
     "corestore": "^7.4.5",
     "hyperbee": "^2.24.3",
-    "hypercore": "^11.11.2",
-    "hyperswarm": "^4.12.1"
+    "hypercore": "^11.11.2"
   },
   "devDependencies": {
     "@prev/corestore": "npm:corestore@^6.17.0",


### PR DESCRIPTION
- [x] [ getCore, getBase and getBee shouldn't be async ]( https://github.com/tetherto/hp-svc-facs-store/blob/70bd7f7518dba02437e8d881139d7053829285f8/index.js#L19-L31 )
    - Not sure about this as this facility is used in a few different places and we don't want to break the API without updating it's usages. Plus, this does not cause any issues.
- [x] [ swarmBase shouldn't create new swarm each time, as only one should exist ]( https://github.com/tetherto/hp-svc-facs-store/blob/70bd7f7518dba02437e8d881139d7053829285f8/index.js#L59-L64 )
    - Changed this function such that it throws an error when swarmBase was previously already called.
- [x] [ exists function is non-sensical since store.get will always return a core ]( https://github.com/tetherto/hp-svc-facs-store/blob/70bd7f7518dba02437e8d881139d7053829285f8/index.js#L66-L69 )
    - Replaced this function to remove logic from it and always return true. (didn't remove because we might be using it somewhere)
- [x] [ Issue in the unlink function](https://github.com/tetherto/hp-svc-facs-store/blob/70bd7f7518dba02437e8d881139d7053829285f8/index.js#L71-L76 ): This function doesn't work, because core.length is set only after ready completes (so first call await core.ready() before getting core.length) https://github.com/holepunchto/hypercore?tab=readme-ov-file#corelength 
    - Called await core.ready() function before calling core.length
- [x] Agreed that we won't do this: [Use b4a instead of Buffer.from](https://github.com/tetherto/hp-svc-facs-store/blob/70bd7f7518dba02437e8d881139d7053829285f8/index.js#L89)  safer to use b4a.from instead of Buffer.from, for cross compat
    - Not sure if it's needed as we'd only work on NodeJS platform and we use buffer in a few different places
