### PR TITLE
ci: add OIDC npm publish on version tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,17 @@
+name: Publish
+on:
+  push:
+    tags:
+      - v*
+permissions:
+  id-token: write
+  contents: write
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment:
+      name: release
+    name: Publish
+    steps:
+      - uses: holepunchto/actions/node-base@v1
+      - uses: holepunchto/actions/publish@v1

--- a/package.json
+++ b/package.json
@@ -44,5 +44,9 @@
       "name": "prdn",
       "email": "paolo@tether.to"
     }
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  }
 }


### PR DESCRIPTION
## Summary
- Keep existing `tag-release.yml` so merged `Release:` PRs still create `v*` tags.
- Add the WDK OIDC publish workflow so those tags publish `@tetherto/hp-svc-facs-store` to public npm.
- Set `publishConfig.access` to public.