### PR TITLE
chore: exclude .github from the npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+node_modules
+.github


### PR DESCRIPTION
## Summary
- Add `.npmignore` so `node_modules` and `.github` are not included in the published tarball.

## Test plan
- [ ] Confirm the next publish no longer contains `.github/`.