### PR TITLE
ci: pass ref-name so GitHub releases use v$VERSION

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,4 +41,10 @@ jobs:
       id-token: write
     steps:
       - uses: holepunchto/actions/node-base@v1
+      - id: pkg
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
       - uses: holepunchto/actions/publish@v1
+        with:
+          ref-name: ${{ steps.pkg.outputs.tag }}


### PR DESCRIPTION
## Summary
- Pass `ref-name` into `holepunchto/actions/publish@v1` so the GitHub Release uses `v$VERSION` instead of `main`.

## Test plan
- [ ] Next Release creates GitHub release `v*` not `main`.
- [ ] Requires holepunchto/actions `v1` tag to include PR #106.

